### PR TITLE
Revert to static deploy, use envs in ci

### DIFF
--- a/.env
+++ b/.env
@@ -5,5 +5,4 @@ BOOTNODES_URL=https://bootnodes.vocdoni.net/gateways.dev.json
 ETH_NETWORK_ID=goerli
 # Traefik
 DOMAIN=bridge.example.com
-LE_MAIL=info@example.com
-
+LE_EMAIL=info@example.com

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,9 @@ jobs:
         run: |
          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | tr '/' '-' )"
 
-      - name: Push to Docker Hub and ghcr.io
+      - name: Push to Docker Hub and ghcr.io (main)
         uses: docker/build-push-action@v2
+        if: github.ref == 'refs/heads/main'
         with:
           context: .
           file: ./Dockerfile
@@ -66,3 +67,49 @@ jobs:
           tags: |
             vocdoni/${{ github.event.repository.name }}:latest, vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }},
             ghcr.io/vocdoni/${{ github.event.repository.name }}:latest,ghcr.io/vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }}
+
+      - name: Push to Docker Hub and ghcr.io (main static, development)
+        uses: docker/build-push-action@v2
+        if: github.ref == 'refs/heads/main'
+        with:
+          context: .
+          file: ./Dockerfile.static
+          platforms: linux/amd64
+          push: true
+          tags: |
+            vocdoni/${{ github.event.repository.name }}:latest-static, vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }}-static,
+            ghcr.io/vocdoni/${{ github.event.repository.name }}:latest-static,ghcr.io/vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }}-static
+
+      - name: Push to Docker Hub and ghcr.io (stage)
+        uses: docker/build-push-action@v2
+        if: github.ref == 'refs/heads/stage'
+        with:
+          context: .
+          file: ./Dockerfile.static
+          platforms: linux/amd64
+          environment:
+            VOCDONI_ENVIRONMENT=stg
+            ETH_NETWORK_ID=goerli
+            BOOTNODES_URL=https://bootnodes.vocdoni.net/gateways.stg.json
+          push: true
+          tags: |
+            vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }},
+            ghcr.io/vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }}
+
+      - name: Push to Docker Hub and ghcr.io (release)
+        uses: docker/build-push-action@v2
+        if: github.ref == startsWith(github.ref, 'refs/heads/release')
+        with:
+          context: .
+          file: ./Dockerfile.static
+          platforms: linux/amd64
+          environment:
+            NODE_ENV=production
+            VOCDONI_ENVIRONMENT=prod
+            ETH_NETWORK_ID=xdai
+            ETH_CHAIN_ID=100
+            BOOTNODES_URL=https://bootnodes.vocdoni.net/gateways.json
+          push: true
+          tags: |
+            vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }},
+            ghcr.io/vocdoni/${{ github.event.repository.name }}:${{ steps.var.outputs.branch }}

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,0 +1,24 @@
+# Static web site compiler
+FROM node:14 as builder
+
+ARG NODE_ENV="development"
+ENV NODE_ENV=${NODE_ENV}
+ARG ETH_NETWORK_ID
+ENV ETH_NETWORK_ID=${ETH_NETWORK_ID}
+ARG ETH_CHAIN_ID
+ENV ETH_CHAIN_ID=${ETH_CHAIN_ID}
+ARG ETHERSCAN_PREFIX
+ENV ETHERSCAN_PREFIX=${ETHERSCAN_PREFIX}
+ARG BLOCK_TIME
+ENV BLOCK_TIME=${BLOCK_TIME}
+ARG BOOTNODES_URL="https://bootnodes.vocdoni.net/gateways.dev.json"
+ENV BOOTNODES_URL=${BOOTNODES_URL}
+
+ADD . /app
+WORKDIR /app
+RUN npm install && npm run export
+
+## Static web server
+FROM nginx:1.19
+
+COPY --from=builder /app/build /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # Bridge UI
+
 Frontend for the Vocdoni Bridge voting client
+
+## Docker Builds
+
+There are two types of docker images, bootstrap generated and fully static, depending on the Dockerfile used:
+
+-   `Dockerfile`: By default, the image includes all NodeJS dependencies, and generates the static site at bootstrap based on the env vars provided. Hence, the initial run of the image takes few minutes to start since it has to build itself. This image is for testing and/or developing purposes.
+
+-   `Dockerfile.static`: This image generates the static site at build time, and serves the content with nginx, so once it's built no parameters can be configured at runtime. It starts instantly as you would expect. This is a final image, to be used in production environments.
+
+## Docker compose deployment
+
+To deploy using [Docker Compose](https://docs.docker.com/compose) follow the instructions.
+
+### Prerequisites
+
+-   GNU/Linux based operating system
+-   Docker engine (version 19.03 or above) [Installation](https://docs.docker.com/engine/install/#server)
+-   Docker compose (version 1.24 or above) [Installation](https://docs.docker.com/compose/install)
+-   A DNS domain
+
+### Environment Variables
+
+Configure the `.env` file with the following variables:
+
+-   `BRIDGE_UI_TAG` Docker tag of the image (main, stage, release)
+-   `VOCDONI_ENVIRONMENT` Enviromnent type (dev, stage, prod)
+-   `BOOTNODES_URL` URL to fetch the JSON containing nodes information (gateways, etc.)
+-   `ETH_NETWORK_ID` Ethereum nework ID (xdai, goerli...)
+-   `DOMAIN` Domain name to be served. Used by Traefik to fetch SSL certificates from Let's Encrypt
+-   `LE_EMAIL` Email associated to the domain. Used by Traefik to fetch SSL certificates from Let's Encrypt
+
+TBD: Add all remaining variables.
+
+### Deployment
+
+Pull the images
+
+`docker-compose pull`
+
+Deploy all services
+
+`docker-compose up -d`
+
+After a while, the bridge should be ready at https://<yourdomain>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: "3"
 services:
   bridge-ui:
-    image: ghcr.io/vocdoni/bridge-ui:main
-    container_name: "bridge-ui"
+    image: ghcr.io/vocdoni/bridge-ui:${BRIDGE_UI_TAG:-main}
     env_file:
       - .env
+    container_name: "bridge-ui"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.bootnodes.rule=Host(`${DOMAIN}`)"


### PR DESCRIPTION
I propose rolling back to a pure static model, setting the required env variables in the CI, at build time.

Setting them at runtime and building the site again causes a cascade of problems and is not worth adding this, since it breaks the docker purpose and is not compatible with production deployments.