### PR TITLE
fix: envelopeType flag added

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 const env = require("./env-config.js");
 
 module.exports = {
-    exportTrailingSlash: true,
+    trailingSlash: true,
     env,
 };

--- a/pages/processes/new.tsx
+++ b/pages/processes/new.tsx
@@ -462,7 +462,7 @@ const NewProcessPage = () => {
                 "questionCount"
             > & { metadata: ProcessMetadata } = {
                 mode: ProcessMode.make({ autoStart: true }),
-                envelopeType: ProcessEnvelopeType.make({}), // bit mask
+                envelopeType: ProcessEnvelopeType.make({ encryptedVotes: envelopeType.hasEncryptedVotes }), // bit mask
                 censusOrigin: ProcessCensusOrigin.ERC20,
                 metadata: metadata,
                 censusRoot: proof.storageHash,


### PR DESCRIPTION
# Short description
This PR aims to fix the bug mentioned on issue VOT-67 Encrypted proposal not working, it sets the flag on the `envelopeType` property of the `processParamsPre` when creating a new process.

# How can it be tested
Create a new process and set the process with `Encrypted Results`

# Tracker ID
https://linear.app/aragon/issue/VOT-67/encrypted-proposal-not-working
