### PR TITLE
Fix: Fallback logo

### DIFF
--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import Link from "next/link";
+import { FALLBACK_TOKEN_ICON } from "../lib/constants";
 
 const Container = styled.div`
     background: white;
@@ -80,7 +81,7 @@ const ClickableCard = React.forwardRef<HTMLDivElement, CardProps>(
     ({ onClick, icon, rightText, name, children }, ref) => {
         return (
             <Card onClick={onClick} ref={ref}>
-                <TokenLogo src={icon} />
+                <TokenLogo src={icon} onError={loadFallback} />
                 {rightText && <RightText>{rightText}</RightText>}
                 <Text>
                     <Name>{name}</Name>
@@ -90,6 +91,10 @@ const ClickableCard = React.forwardRef<HTMLDivElement, CardProps>(
         );
     }
 );
+
+function loadFallback(event) {
+    event.target.src = FALLBACK_TOKEN_ICON;
+}
 
 const TokenCard = ({ children, ...props }: CardProps) => (
     <Container>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,14 +4,7 @@ import TokenAmount from "token-amount";
 import Bluebird from "bluebird";
 import { NO_TOKEN_BALANCE } from "./errors";
 import { ProcessInfo, TokenInfo } from "./types";
-import { FALLBACK_TOKEN_ICON } from "./constants";
-
-// from aragon/use-wallet
-const TRUST_WALLET_BASE_URL =
-  "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum";
-const EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";
-
-// VOCDONI API's
+import { FALLBACK_TOKEN_ICON, EMPTY_ADDRESS, TRUST_WALLET_BASE_URL } from "./constants";
 
 export async function getTokenProcesses(
   tokenAddr: string,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,16 +1,20 @@
-import { CensusErc20Api, GatewayPool, ITokenStorageProofContract, VotingApi } from "dvote-js"
-import { NO_TOKEN_BALANCE } from "./errors"
-import { ProcessInfo, TokenInfo } from "./types"
-import { BigNumber, Contract, providers, Signer, utils } from "ethers"
-import TokenAmount from "token-amount"
-import { FALLBACK_TOKEN_ICON } from "./constants"
-import Bluebird from "bluebird"
-
-// from aragon/use-wallet
-const TRUST_WALLET_BASE_URL =
-    'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum'
-const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
-
+import {
+    CensusErc20Api,
+    GatewayPool,
+    ITokenStorageProofContract,
+    VotingApi,
+} from "dvote-js";
+import { NO_TOKEN_BALANCE } from "./errors";
+import { ProcessInfo, TokenInfo } from "./types";
+import { BigNumber, Contract, providers, Signer, utils } from "ethers";
+import TokenAmount from "token-amount";
+import {
+    EMPTY_ADDRESS,
+    ERC20_ABI,
+    FALLBACK_TOKEN_ICON,
+    TRUST_WALLET_BASE_URL,
+} from "./constants";
+import Bluebird from "bluebird";
 
 // VOCDONI API's
 
@@ -34,40 +38,66 @@ export async function getTokenProcesses(
     }
 }
 
-export async function getProcessInfo(processId: string, pool: GatewayPool): Promise<ProcessInfo> {
+export async function getProcessInfo(
+    processId: string,
+    pool: GatewayPool
+): Promise<ProcessInfo> {
     const results = await Promise.all([
         VotingApi.getProcessMetadata(processId, pool),
-        VotingApi.getProcessParameters(processId, pool)
-    ])
+        VotingApi.getProcessParameters(processId, pool),
+    ]);
 
     return {
         metadata: results[0],
         parameters: results[1],
         id: processId, // pass-through to have the value for links
-        tokenAddress: results[1].entityAddress.toLowerCase()
-    }
+        tokenAddress: results[1].entityAddress.toLowerCase(),
+    };
 }
 
-export async function getProcessList(tokenAddress: string, pool: GatewayPool): Promise<string[]> {
-    let result: string[] = []
-    let from = 0
+export async function getProcessList(
+    tokenAddress: string,
+    pool: GatewayPool
+): Promise<string[]> {
+    let result: string[] = [];
+    let from = 0;
 
     while (true) {
-        const processList = await VotingApi.getProcessList({ entityId: tokenAddress, from }, pool)
-        if (processList.length == 0) return result
+        const processList = await VotingApi.getProcessList(
+            { entityId: tokenAddress, from },
+            pool
+        );
+        if (processList.length == 0) return result;
 
-        result = result.concat(processList.map(id => "0x" + id))
-        from += processList.length
+        result = result.concat(processList.map((id) => "0x" + id));
+        from += processList.length;
     }
 }
 
-export async function registerToken(tokenAddress: string, holderAddress: string, pool: GatewayPool, signer: Signer) {
+export async function registerToken(
+    tokenAddress: string,
+    holderAddress: string,
+    pool: GatewayPool,
+    signer: Signer
+) {
     try {
-        const tokenBalanceMappingPosition = await findTokenBalanceMappingPosition(tokenAddress, holderAddress, pool)
-        const blockNumber = await pool.provider.getBlockNumber() - 1
-        const balanceSlot = CensusErc20Api.getHolderBalanceSlot(holderAddress, tokenBalanceMappingPosition)
-        const result = await CensusErc20Api.generateProof(tokenAddress, [balanceSlot], blockNumber, pool.provider as providers.JsonRpcProvider)
-        const { blockHeaderRLP, accountProofRLP, storageProofsRLP } = result
+        const tokenBalanceMappingPosition = await findTokenBalanceMappingPosition(
+            tokenAddress,
+            holderAddress,
+            pool
+        );
+        const blockNumber = (await pool.provider.getBlockNumber()) - 1;
+        const balanceSlot = CensusErc20Api.getHolderBalanceSlot(
+            holderAddress,
+            tokenBalanceMappingPosition
+        );
+        const result = await CensusErc20Api.generateProof(
+            tokenAddress,
+            [balanceSlot],
+            blockNumber,
+            pool.provider as providers.JsonRpcProvider
+        );
+        const { blockHeaderRLP, accountProofRLP, storageProofsRLP } = result;
 
         await CensusErc20Api.registerToken(
             tokenAddress,
@@ -78,159 +108,208 @@ export async function registerToken(tokenAddress: string, holderAddress: string,
             Buffer.from(storageProofsRLP[0].replace("0x", ""), "hex"),
             signer,
             pool
-        )
-    }
-    catch (err) {
-        if (err && err.message == NO_TOKEN_BALANCE) throw err
-        throw new Error("The token internal details cannot be chacked")
+        );
+    } catch (err) {
+        if (err && err.message == NO_TOKEN_BALANCE) throw err;
+        throw new Error("The token internal details cannot be chacked");
     }
 }
 
-export async function findTokenBalanceMappingPosition(tokenAddress: string, holderAddress: string, pool: GatewayPool) {
-    const verify = true
+export async function findTokenBalanceMappingPosition(
+    tokenAddress: string,
+    holderAddress: string,
+    pool: GatewayPool
+) {
+    const verify = true;
     try {
-        const blockNumber = await pool.provider.getBlockNumber()
-        const balance = await balanceOf(tokenAddress, holderAddress, pool)
-        if (balance.isZero()) throw new Error(NO_TOKEN_BALANCE)
+        const blockNumber = await pool.provider.getBlockNumber();
+        const balance = await balanceOf(tokenAddress, holderAddress, pool);
+        if (balance.isZero()) throw new Error(NO_TOKEN_BALANCE);
 
         for (let i = 0; i < 50; i++) {
-            const tokenBalanceMappingPosition = i
+            const tokenBalanceMappingPosition = i;
 
-            const balanceSlot = CensusErc20Api.getHolderBalanceSlot(holderAddress, tokenBalanceMappingPosition)
+            const balanceSlot = CensusErc20Api.getHolderBalanceSlot(
+                holderAddress,
+                tokenBalanceMappingPosition
+            );
 
-            const result = await CensusErc20Api
-                .generateProof(tokenAddress, [balanceSlot], blockNumber, pool.provider as providers.JsonRpcProvider, { verify })
-                .catch(() => null) // Failed => ignore
+            const result = await CensusErc20Api.generateProof(
+                tokenAddress,
+                [balanceSlot],
+                blockNumber,
+                pool.provider as providers.JsonRpcProvider,
+                { verify }
+            ).catch(() => null); // Failed => ignore
 
-            if (result == null || !result.proof) continue
+            if (result == null || !result.proof) continue;
 
-            const onChainBalance = BigNumber.from(result.proof.storageProof[0].value)
+            const onChainBalance = BigNumber.from(
+                result.proof.storageProof[0].value
+            );
             if (!onChainBalance.eq(balance)) {
-                console.warn("The proved balance does not match the on-chain balance:", result.proof.storageProof[0].value, "vs", balance.toHexString())
-                continue
+                console.warn(
+                    "The proved balance does not match the on-chain balance:",
+                    result.proof.storageProof[0].value,
+                    "vs",
+                    balance.toHexString()
+                );
+                continue;
             }
 
             // FOUND
-            return tokenBalanceMappingPosition
+            return tokenBalanceMappingPosition;
         }
-        return null
-    }
-    catch (err) {
-        throw err
+        return null;
+    } catch (err) {
+        throw err;
     }
 }
 
 // ERC20 API
 
-const ERC20_ABI = [
-    // Read-Only Functions
-    "function name() public view returns (string)",
-    "function symbol() public view returns (string)",
-    "function decimals() public view returns (uint8)",
-    "function balanceOf(address _owner) public view returns (uint256 balance)",
-    "function totalSupply() public view returns (uint256)",
-]
-
-export function getTokenInfo(address: string, pool: GatewayPool): Promise<TokenInfo> {
-    const tokenInstance = new Contract(address, ERC20_ABI, pool.provider)
+export function getTokenInfo(
+    address: string,
+    pool: GatewayPool
+): Promise<TokenInfo> {
+    const tokenInstance = new Contract(address, ERC20_ABI, pool.provider);
 
     return Promise.all([
         tokenInstance.name(),
         tokenInstance.symbol(),
         tokenInstance.totalSupply(),
         tokenInstance.decimals(),
-        CensusErc20Api.getBalanceMappingPosition(address, pool).catch(() => BigNumber.from(-1)),
-        getProcessList(address, pool)
-    ]).then(([name, symbol, totalSupply, decimals, balMappingPos, pids]: [string, string, BigNumber, number, BigNumber, string[]]) => {
-        return {
-            name,
-            symbol,
-            totalSupply,
-            totalSupplyFormatted: new TokenAmount(totalSupply.toString(), decimals, { symbol }).format(),
-            decimals,
-            address,
-            balanceMappingPosition: balMappingPos.toNumber(),
-            icon: tokenIconUrl(address),
-            processes: pids
+        CensusErc20Api.getBalanceMappingPosition(address, pool).catch(() =>
+            BigNumber.from(-1)
+        ),
+        getProcessList(address, pool),
+    ]).then(
+        ([name, symbol, totalSupply, decimals, balMappingPos, pids]: [
+            string,
+            string,
+            BigNumber,
+            number,
+            BigNumber,
+            string[]
+        ]) => {
+            return {
+                name,
+                symbol,
+                totalSupply,
+                totalSupplyFormatted: new TokenAmount(
+                    totalSupply.toString(),
+                    decimals,
+                    { symbol }
+                ).format(),
+                decimals,
+                address,
+                balanceMappingPosition: balMappingPos.toNumber(),
+                icon: tokenIconUrl(address),
+                processes: pids,
+            };
         }
-    })
+    );
 }
 
-export function balanceOf(tokenAddress: string, holderAddress: string, pool: GatewayPool): Promise<BigNumber> {
-    const tokenInstance = new Contract(tokenAddress, ERC20_ABI, pool.provider)
-    return tokenInstance.balanceOf(holderAddress)
+export function balanceOf(
+    tokenAddress: string,
+    holderAddress: string,
+    pool: GatewayPool
+): Promise<BigNumber> {
+    const tokenInstance = new Contract(tokenAddress, ERC20_ABI, pool.provider);
+    return tokenInstance.balanceOf(holderAddress);
 }
 
-export function hasBalance(tokenAddress: string, holderAddress: string, pool: GatewayPool): Promise<boolean> {
-    const tokenInstance = new Contract(tokenAddress, ERC20_ABI, pool.provider)
-    return tokenInstance.balanceOf(holderAddress).then(balance => !balance.isZero())
+export function hasBalance(
+    tokenAddress: string,
+    holderAddress: string,
+    pool: GatewayPool
+): Promise<boolean> {
+    const tokenInstance = new Contract(tokenAddress, ERC20_ABI, pool.provider);
+    return tokenInstance
+        .balanceOf(holderAddress)
+        .then((balance) => !balance.isZero());
 }
 
 /** Retrieves the list of registered ERC20 token addresses on the smart contract. IMPORTANT: If no new tokens are registered, `null` is returned. */
-export function getRegisteredTokenList(currentTokenCount: number, pool: GatewayPool): Promise<string[]> {
-    let contractInstance: ITokenStorageProofContract
-    return pool.getTokenStorageProofInstance()
-        .then(instance => {
-            contractInstance = instance
+export function getRegisteredTokenList(
+    currentTokenCount: number,
+    pool: GatewayPool
+): Promise<string[]> {
+    let contractInstance: ITokenStorageProofContract;
+    return pool
+        .getTokenStorageProofInstance()
+        .then((instance) => {
+            contractInstance = instance;
 
-            return contractInstance.tokenCount()
+            return contractInstance.tokenCount();
         })
-        .then(count => {
-            if (count == currentTokenCount) return Promise.resolve(null)
+        .then((count) => {
+            if (count == currentTokenCount) return Promise.resolve(null);
 
-            return Bluebird.map(Array.from(Array(count).keys()), idx => {
-                return contractInstance.tokenAddresses(idx).then(addr => addr.toLowerCase())
-            }, { concurrency: 100 })
-        })
+            return Bluebird.map(
+                Array.from(Array(count).keys()),
+                (idx) => {
+                    return contractInstance
+                        .tokenAddresses(idx)
+                        .then((addr) => addr.toLowerCase());
+                },
+                { concurrency: 100 }
+            );
+        });
 }
 
 /** Counts how many ERC20 tokens are registered on the smart contract. */
 export function getRegisteredTokenCount(pool: GatewayPool): Promise<number> {
-    let contractInstance: ITokenStorageProofContract
-    return pool.getTokenStorageProofInstance()
-        .then(instance => {
-            contractInstance = instance
+    let contractInstance: ITokenStorageProofContract;
+    return pool.getTokenStorageProofInstance().then((instance) => {
+        contractInstance = instance;
 
-            return contractInstance.tokenCount()
-        })
+        return contractInstance.tokenCount();
+    });
 }
 
 // INTERNAL HELPERS
 
+function tokenIconUrl(address = "") {
+    return FALLBACK_TOKEN_ICON;
 
-function tokenIconUrl(address = '') {
-    if (process.env.ETH_NETWORK_ID == "goerli") return FALLBACK_TOKEN_ICON
+    // FIXME Currently, fetching data from raw.githubusercontent.com/trustwallet/<...>
+    // doesn't work. In the meantime, to avoid unnecessary
+    // data fetching, every token will be assigned the fallback icon by default until a
+    // new mechanism is implemented. [VR 21-04-2021]
+    if (process.env.ETH_NETWORK_ID == "goerli") return FALLBACK_TOKEN_ICON;
 
     try {
-        address = toChecksumAddress(address.trim())
+        address = toChecksumAddress(address.trim());
     } catch (err) {
-        return null
+        return null;
     }
 
     if (address === EMPTY_ADDRESS) {
-        return `${TRUST_WALLET_BASE_URL}/info/logo.png`
+        return `${TRUST_WALLET_BASE_URL}/info/logo.png`;
     }
 
-    return `${TRUST_WALLET_BASE_URL}/assets/${address}/logo.png`
+    return `${TRUST_WALLET_BASE_URL}/assets/${address}/logo.png`;
 }
 
 function toChecksumAddress(address) {
     if (!/^(0x)?[0-9a-f]{40}$/i.test(address)) {
         throw new Error(
             'Given address "' + address + '" is not a valid Ethereum address.'
-        )
+        );
     }
 
-    const addressHash = utils.keccak256(address).replace(/^0x/i, '')
-    let checksumAddress = '0x'
+    const addressHash = utils.keccak256(address).replace(/^0x/i, "");
+    let checksumAddress = "0x";
 
     for (let i = 0; i < address.length; i++) {
         // If ith character is 9 to f then make it uppercase
         if (parseInt(addressHash[i], 16) > 7) {
-            checksumAddress += address[i].toUpperCase()
+            checksumAddress += address[i].toUpperCase();
         } else {
-            checksumAddress += address[i]
+            checksumAddress += address[i];
         }
     }
-    return checksumAddress
+    return checksumAddress;
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,1 +1,15 @@
-export const FALLBACK_TOKEN_ICON = "/media/coin.svg"
+export const FALLBACK_TOKEN_ICON = "/media/coin.svg";
+
+export const ERC20_ABI = [
+    // Read-Only Functions
+    "function name() public view returns (string)",
+    "function symbol() public view returns (string)",
+    "function decimals() public view returns (uint8)",
+    "function balanceOf(address _owner) public view returns (uint256 balance)",
+    "function totalSupply() public view returns (uint256)",
+];
+
+// from aragon/use-wallet
+export const TRUST_WALLET_BASE_URL =
+    "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum";
+export const EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";

--- a/lib/hooks/tokens.tsx
+++ b/lib/hooks/tokens.tsx
@@ -1,118 +1,140 @@
-import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
-import { getTokenInfo } from '../api'
-import { TokenInfo } from '../types'
-import { usePool } from '@vocdoni/react-hooks'
+import React, {
+    useCallback,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
+import { getTokenInfo } from "../api";
+import { TokenInfo } from "../types";
+import { usePool } from "@vocdoni/react-hooks";
 // import { useLoadingAlert } from './loading-alert'
-import { useMessageAlert } from './message-alert'
+import { useMessageAlert } from "./message-alert";
 
 const UseTokenContext = React.createContext<{
-    currentTokens: Map<string, TokenInfo>,
-    resolveTokenInfo: (address: string) => Promise<TokenInfo>,
-    refreshTokenInfo: (address: string) => Promise<TokenInfo>
-}>({ currentTokens: new Map(), resolveTokenInfo: () => Promise.reject(new Error("Not initialized")), refreshTokenInfo: () => Promise.reject(new Error("Not initialized")) })
+    currentTokens: Map<string, TokenInfo>;
+    resolveTokenInfo: (address: string) => Promise<TokenInfo>;
+    refreshTokenInfo: (address: string) => Promise<TokenInfo>;
+}>({
+    currentTokens: new Map(),
+    resolveTokenInfo: () => Promise.reject(new Error("Not initialized")),
+    refreshTokenInfo: () => Promise.reject(new Error("Not initialized")),
+});
 
 export function useToken(address: string): TokenInfo | null {
-    const tokenContext = useContext(UseTokenContext)
-    const [tokenInfo, setTokenInfo] = useState<TokenInfo>(null)
-    const { setAlertMessage } = useMessageAlert()
+    const tokenContext = useContext(UseTokenContext);
+    const [tokenInfo, setTokenInfo] = useState<TokenInfo>(null);
+    const { setAlertMessage } = useMessageAlert();
     // const { setLoadingMessage, hideLoading } = useLoadingAlert()
 
     useEffect(() => {
-        let ignore = false
+        let ignore = false;
 
         const update = () => {
-            if (!address) return
+            if (!address) return;
 
-            tokenContext.resolveTokenInfo(address)
-                .then(newInfo => {
-                    if (ignore) return
-                    setTokenInfo(newInfo)
-                }).catch(err => {
-                    setAlertMessage("The token details could not be loaded")
-                    console.error(err)
+            tokenContext
+                .resolveTokenInfo(address)
+                .then((newInfo) => {
+                    if (ignore) return;
+                    setTokenInfo(newInfo);
                 })
-        }
-        update()
+                .catch((err) => {
+                    setAlertMessage("The token details could not be loaded");
+                    console.error(err);
+                });
+        };
+        update();
 
         return () => {
-            ignore = true
-        }
-    }, [address])
+            ignore = true;
+        };
+    }, [address]);
 
     if (tokenContext === null) {
         throw new Error(
-            'useToken() can only be used inside of <UseTokenProvider />, ' +
-            'please declare it at a higher level.'
-        )
+            "useToken() can only be used inside of <UseTokenProvider />, " +
+                "please declare it at a higher level."
+        );
     }
 
-    return tokenInfo
+    return tokenInfo;
 }
 
 /** Returns an arran containing the available information about the given addresses */
 export function useTokens(addresses: string[]) {
-    const tokenContext = useContext(UseTokenContext)
-    const [bool, setBool] = useState(false) // to force rerender
+    const tokenContext = useContext(UseTokenContext);
+    const [bool, setBool] = useState(false); // to force rerender
     // const { pool } = usePool()
     // const { setAlertMessage } = useMessageAlert()
 
     useEffect(() => {
-        if (!addresses || !addresses.length) return
+        if (!addresses || !addresses.length) return;
 
         // Signal a refresh on the current token addresses
-        Promise.all(addresses.map(address =>
-            tokenContext.resolveTokenInfo(address)
-        )).then(() => {
-            setBool(!bool)
-        }).catch(err => {
-            // setAlertMessage("Some token details could not be loaded")
+        Promise.all(
+            addresses.map((address) => tokenContext.resolveTokenInfo(address))
+        )
+            .then(() => {
+                setBool(!bool);
+            })
+            .catch((err) => {
+                // setAlertMessage("Some token details could not be loaded")
 
-            console.error(err)
-            setBool(!bool)
-        })
+                console.error(err);
+                setBool(!bool);
+            });
 
-        return () => { }
-    }, [addresses])
+        return () => {};
+    }, [addresses]);
 
     if (tokenContext === null) {
         throw new Error(
-            'useTokens() can only be used inside of <UseTokenProvider />, ' +
-            'please declare it at a higher level.'
-        )
+            "useTokens() can only be used inside of <UseTokenProvider />, " +
+                "please declare it at a higher level."
+        );
     }
-    return tokenContext.currentTokens
+    return tokenContext.currentTokens;
 }
 
 export function UseTokenProvider({ children }) {
     // TODO: Use swr
 
-    const tokens = useRef(new Map<string, TokenInfo>())
-    const { poolPromise } = usePool()
+    const tokens = useRef(new Map<string, TokenInfo>());
+    const { poolPromise } = usePool();
 
-    const resolveTokenInfo: (address: string) => Promise<TokenInfo> =
-        useCallback((address: string) => {
-            if (!address) return Promise.resolve(null)
-            else if (tokens.current.has(address.toLowerCase())) { // cached
-                return Promise.resolve(tokens.current.get(address.toLowerCase()))
-            }
-            return loadTokenInfo(address)
-        }, [])
+    const resolveTokenInfo: (
+        address: string
+    ) => Promise<TokenInfo> = useCallback((address: string) => {
+        if (!address) return Promise.resolve(null);
+        else if (tokens.current.has(address.toLowerCase())) {
+            // cached
+            return Promise.resolve(tokens.current.get(address.toLowerCase()));
+        }
+        return loadTokenInfo(address);
+    }, []);
 
-    const loadTokenInfo: (address: string) => Promise<TokenInfo> =
-        useCallback((address: string) => {
+    const loadTokenInfo: (address: string) => Promise<TokenInfo> = useCallback(
+        (address: string) => {
             return poolPromise
-                .then(pool => getTokenInfo(address, pool))
-                .then(tokenInfo => {
-                    tokens.current.set(address.toLowerCase(), tokenInfo)
-                    return tokenInfo
-                })
-        }, [])
+                .then((pool) => getTokenInfo(address, pool))
+                .then((tokenInfo) => {
+                    tokens.current.set(address.toLowerCase(), tokenInfo);
+                    return tokenInfo;
+                });
+        },
+        []
+    );
 
     return (
         <UseTokenContext.Provider
-            value={{ currentTokens: tokens.current, resolveTokenInfo, refreshTokenInfo: loadTokenInfo }}
+            value={{
+                currentTokens: tokens.current,
+                resolveTokenInfo,
+                refreshTokenInfo: loadTokenInfo,
+            }}
         >
             {children}
         </UseTokenContext.Provider>
-    )
+    );
 }


### PR DESCRIPTION
# Short description
Fetching data for token logos currently doesn't work. This PR fixes this by defaulting to a fallback logo for every token. Additionally, an error handling mechanism was added, such that the fallback token is used if there's an error loading a token's logo.

# How can it be tested
Open the staging environment and check that every token shows the fallback logo.

# Tracker ID
https://linear.app/aragon/issue/VOT-68/token-icons-not-found-on-rinkeby
