### PR TITLE
fix: maxValue calculated correctly

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import { ProcessMetadata } from "dvote-js";
 import { utils } from "ethers";
 import { FALLBACK_TOKEN_ICON, EMPTY_ADDRESS, TRUST_WALLET_BASE_URL } from "./constants";
 
@@ -65,3 +66,11 @@ function toChecksumAddress(address) {
   return checksumAddress;
 }
 
+/* find the question with the most choices */
+export function findMaxValue(metadata: ProcessMetadata) {
+  let longest = 0
+  metadata.questions.forEach(question => {
+    longest = Math.max(longest, question.choices.length)
+  });
+  return longest
+}

--- a/pages/processes/new.tsx
+++ b/pages/processes/new.tsx
@@ -30,6 +30,8 @@ import { handleValidation } from "../../lib/processValidator";
 import { useSigner } from "../../lib/hooks/useSigner";
 import { ConnectButton } from "../../components/connect-button";
 
+import { findMaxValue } from "../../lib/utils"
+
 const NewProcessContainer = styled.div`
   input[type="text"],
   textarea {
@@ -445,7 +447,7 @@ const NewProcessPage = () => {
         startBlock,
         blockCount,
         maxCount: metadata.questions.length,
-        maxValue: 3,
+        maxValue: findMaxValue(metadata),
         maxTotalCost: 0,
         costExponent: 10000,
         maxVoteOverwrites: 1,


### PR DESCRIPTION
# Short description
`maxValue` is calculated correctly as the maximum number of options considering all the questions i.e. Proposal has 1 question with 2 choices, another question with 4 choices, and a last question with 3 choices... maxCount=3, maxValue=4?

# How can it be tested
Make a new process that has multiple questions with different numbers of choices, console.log the metadata to see `maxValue`

# Tracker ID
VOT-168
