### PR TITLE
Fix: Vote only if process started

### DIFF
--- a/lib/hooks/process/useProcessDate.ts
+++ b/lib/hooks/process/useProcessDate.ts
@@ -11,12 +11,12 @@ export const useProcessDate = (info: ProcessInfo) => {
   const fetchDates = async (startBlock: number, blockCount: number) => {
     try {
       const pool = await poolPromise;
-      const start = VotingApi.estimateDateAtBlock(startBlock, pool);
-      const end = VotingApi.estimateDateAtBlock(startBlock + blockCount, pool);
+      const getStart = VotingApi.estimateDateAtBlock(startBlock, pool);
+      const getEnd = VotingApi.estimateDateAtBlock(startBlock + blockCount, pool);
 
-      const [a, b] = await Promise.all([start, end]);
+      const [start, end] = await Promise.all([getStart, getEnd]);
 
-      return { start: a, end: b };
+      return { start, end };
     } catch (error) {
       console.log(error.message);
       console.log("Error in useProcessInfo hook: ", error.message);
@@ -35,9 +35,14 @@ export const useProcessDate = (info: ProcessInfo) => {
     if (datesInfo) return dayjs().isAfter(datesInfo.end);
   }, [datesInfo]);
 
+  const hasStarted = useMemo(() => {
+    if (datesInfo) return dayjs().isAfter(datesInfo.start);
+  }, [datesInfo]);
+
   return {
     datesInfo,
     datesError,
     hasEnded,
+    hasStarted,
   };
 };

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -138,6 +138,8 @@ const ProcessPage = () => {
               ? "You're not a token holder"
               : !hasStarted
               ? "Process has not started"
+              : alreadyVoted
+              ? "You already voted"
               : !questionsFilled
               ? "Fill all the choices"
               : "Submit your vote"}

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -44,7 +44,7 @@ const ProcessPage = () => {
 
   const { process } = useProcess(processId);
   const token = useToken(process?.entity);
-  const { datesInfo, hasEnded } = useProcessDate(process);
+  const { datesInfo, hasEnded, hasStarted } = useProcessDate(process);
   const { results, updateResults } = useProcessInfo(process, token);
   const { weights } = useWeights({
     processId,
@@ -62,7 +62,7 @@ const ProcessPage = () => {
   const questionsFilled = allQuestionsChosen && areAllNumbers(status.choices);
   const alreadyVoted = voteStatus?.registered;
 
-  const canVote = !alreadyVoted && !hasEnded && inCensus;
+  const canVote = !alreadyVoted && !hasEnded && inCensus && hasStarted;
 
   const onVoteSubmit = async () => {
     if (!isConnected) {
@@ -128,7 +128,7 @@ const ProcessPage = () => {
       ) : (
         <ButtonContainer>
           <Button
-            // Improve this conditional
+            // @TODO: Improve this conditional
             disabled={!isConnected ? false : !canVote || !questionsFilled}
             onClick={onVoteSubmit}
           >
@@ -136,6 +136,8 @@ const ProcessPage = () => {
               ? "Connect your wallet"
               : !inCensus
               ? "You're not a token holder"
+              : !hasStarted
+              ? "Process has not started"
               : !questionsFilled
               ? "Fill all the choices"
               : "Submit your vote"}


### PR DESCRIPTION
# Short description
In the current app, the user is able to `Submit Vote` even tho the process has not started yet, we fix this in this PR

# How can it be tested
- Go to the review app 
- Create a process (Or go to one that has not started yet)
- You wont be able to vote because the process has not started

# Tracker ID
https://linear.app/aragon/issue/VOT-182/voting-before-start
