### PR TITLE
fixed voting before start

### DIFF
--- a/lib/hooks/process/useProcessDate.ts
+++ b/lib/hooks/process/useProcessDate.ts
@@ -35,9 +35,14 @@ export const useProcessDate = (info: ProcessInfo) => {
     if (datesInfo) return dayjs().isAfter(datesInfo.end);
   }, [datesInfo]);
 
+  const hasStarted = useMemo(() => {
+    if (datesInfo) return dayjs().isAfter(datesInfo.start);
+  }, [datesInfo]);
+
   return {
     datesInfo,
     datesError,
     hasEnded,
+    hasStarted,
   };
 };

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -44,7 +44,7 @@ const ProcessPage = () => {
 
   const { process } = useProcess(processId);
   const token = useToken(process?.entity);
-  const { datesInfo, hasEnded } = useProcessDate(process);
+  const { datesInfo, hasEnded, hasStarted } = useProcessDate(process);
   const { results, updateResults } = useProcessInfo(process, token);
   const { weights } = useWeights({
     processId,
@@ -62,7 +62,7 @@ const ProcessPage = () => {
   const questionsFilled = allQuestionsChosen && areAllNumbers(status.choices);
   const alreadyVoted = voteStatus?.registered;
 
-  const canVote = !alreadyVoted && !hasEnded && inCensus;
+  const canVote = !alreadyVoted && !hasEnded && inCensus && hasStarted;
 
   const onVoteSubmit = async () => {
     if (!isConnected) {


### PR DESCRIPTION
# Short description
It disables voting on a process that hasn't started yet.

# How can it be tested
Select an upcoming process, make sure it does not allow you to vote (make sure wallet is connected, too)

# Tracker ID
https://linear.app/aragon/issue/VOT-182/voting-before-start
