### PR TITLE
VOT-147: scroll to top on token page

### DIFF
--- a/pages/tokens/info.tsx
+++ b/pages/tokens/info.tsx
@@ -151,6 +151,9 @@ const TokenPage = () => {
   const { setAlertMessage } = useMessageAlert();
 
   // Effects
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   useEffect(() => {
     const interval = setInterval(() => updateBlockHeight, 1000 * 13);


### PR DESCRIPTION
# Short description
token page will auto scroll to top when navigated to. this should now be true of all routes

# How can it be tested
navigate to a token info page when you are not scrolled to the top

# Tracker ID
VOT-147
