### PR TITLE
tentative fix: double voting

### DIFF
--- a/lib/hooks/process/useVote.ts
+++ b/lib/hooks/process/useVote.ts
@@ -36,12 +36,10 @@ export type StatusAction = ReturnType<typeof updateStatus>;
 export const reducer = (state: VoteStatus, action: StatusAction) => {
   switch (action.type) {
     case "UPDATE_STATUS":
-      console.log(JSON.stringify(state, null, 2));
       const new_state = {
         ...state,
         ...action.status,
       };
-      console.log(JSON.stringify(new_state, null, 2));
       return new_state;
     default:
       return state;

--- a/lib/hooks/process/useVote.ts
+++ b/lib/hooks/process/useVote.ts
@@ -36,11 +36,11 @@ export type StatusAction = ReturnType<typeof updateStatus>;
 export const reducer = (state: VoteStatus, action: StatusAction) => {
   switch (action.type) {
     case "UPDATE_STATUS":
-      const new_state = {
+      state = {
         ...state,
         ...action.status,
       };
-      return new_state;
+      state;
     default:
       return state;
   }
@@ -64,7 +64,9 @@ export const useVote = (process: ProcessInfo) => {
     return voted;
   };
 
-  const voteInfo = useSWR([process?.id, nullifier, wallet], updateVoteInfo);
+  const voteInfo = useSWR([process?.id, nullifier], updateVoteInfo, {
+    isPaused: () => !process?.id || !wallet.account,
+  });
 
   useEffect(() => {
     dispatch({ type: "UPDATE_STATUS", status: { choices: [] } });

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -129,10 +129,6 @@ const ProcessPage = () => {
             disabled={!isConnected ? false : !canVote || !questionsFilled}
             onClick={onVoteSubmit}
           >
-            {console.log("--------------------------------")}
-            {console.log("Already voted? " + alreadyVoted)}
-            {console.log("Vote status registered? " + voteStatus?.registered)}
-            {console.log("status registered? " + status.registered)}
             {status.submitting ? (
               <Spinner />
             ) : !isConnected ? (

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -129,6 +129,10 @@ const ProcessPage = () => {
             disabled={!isConnected ? false : !canVote || !questionsFilled}
             onClick={onVoteSubmit}
           >
+            {console.log("--------------------------------")}
+            {console.log("Already voted? " + alreadyVoted)}
+            {console.log("Vote status registered? " + voteStatus?.registered)}
+            {console.log("status registered? " + status.registered)}
             {status.submitting ? (
               <Spinner />
             ) : !isConnected ? (


### PR DESCRIPTION
# Short description
This PR fixed the UI bug where users are shown that they can vote on a issue they have already voted on.

# How can it be tested
The only way I have found to reproduce this bug is to
- Go to a proposal where you have already voted
- Reload the page - thereby disconnecting the wallet
- Reconnect the wallet

Loading a proposal page directly (thereby not having the wallet connected) might be worth testing as well.

# Tracker ID
VOT-199
