### PR TITLE
chore: changed display of encrypted results

### DIFF
--- a/components/Processes/Questions.tsx
+++ b/components/Processes/Questions.tsx
@@ -25,7 +25,7 @@ const Option = ({ choice, onChoiceSelect, questionId, checked, canVote }) => (
       />
     ) : (
       <ChoiceInfo>
-        <Percentage>{choice.percentage === "N/A" ? "locked" : `${choice.percentage}%`}</Percentage>
+        <Percentage>{choice.percentage === "N/A" ? "Locked" : `${choice.percentage}%`}</Percentage>
       </ChoiceInfo>
     )}
     <OptionTitleContainer>

--- a/components/Processes/Questions.tsx
+++ b/components/Processes/Questions.tsx
@@ -25,7 +25,7 @@ const Option = ({ choice, onChoiceSelect, questionId, checked, canVote }) => (
       />
     ) : (
       <ChoiceInfo>
-        <Percentage>{choice.percentage + "%"}</Percentage>
+        <Percentage>{choice.percentage === "N/A" ? "locked" : `${choice.percentage}%`}</Percentage>
       </ChoiceInfo>
     )}
     <OptionTitleContainer>

--- a/lib/hooks/process/useProcessInfo.ts
+++ b/lib/hooks/process/useProcessInfo.ts
@@ -27,7 +27,7 @@ export const useProcessInfo = (info: ProcessInfo, token: Partial<TokenInfo>) => 
             ({ description, title, choices }) => {
               const choicesFormatted = choices.map(({ title: choiceTitle }) => ({
                 title: choiceTitle.default,
-                percentage: "0.00",
+                percentage: "N/A",
               }));
               return {
                 title: title.default,

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -52,6 +52,7 @@ const ProcessPage = () => {
   const census = useCensusProof(token, process?.parameters.sourceBlockHeight);
   const { status, updateStatus, voteInfo, vote } = useVote(process);
   const { data: voteStatus, mutate: updateVote, isValidating: fetchingVote } = voteInfo;
+  results
   const wallet = useWallet();
 
   const isConnected = !!wallet.account;

--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -52,7 +52,6 @@ const ProcessPage = () => {
   const census = useCensusProof(token, process?.parameters.sourceBlockHeight);
   const { status, updateStatus, voteInfo, vote } = useVote(process);
   const { data: voteStatus, mutate: updateVote, isValidating: fetchingVote } = voteInfo;
-  results
   const wallet = useWallet();
 
   const isConnected = !!wallet.account;


### PR DESCRIPTION
# Short description
Changes the way intermediate results are (not) displayed for encrypted results.

# How can it be tested
check that ongoing encrypted proposals say "locked"

# Tracker ID
VOT-208
