### PR TITLE
Fix: Load added to check token button

### DIFF
--- a/components/searchWidget.tsx
+++ b/components/searchWidget.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { ButtonHTMLAttributes, ThHTMLAttributes } from "react";
 import styled from "styled-components";
 
+import { StyledSpinner } from "../pages/tokens/add";
 import { PrimaryButton } from "./button";
 import TextInput from "./input";
 
@@ -17,9 +18,10 @@ type SearchWidgetProps = {
   onChange: (ev: any) => void;
   onKeyDown: (ev: any) => void;
   onClick: () => void;
+  loading: boolean;
 };
 
-const SearchWidget = ({ onChange, onKeyDown, onClick }: SearchWidgetProps) => {
+const SearchWidget = ({ onChange, onKeyDown, onClick, loading }: SearchWidgetProps) => {
   return (
     <SearchRow>
       <Box>
@@ -30,7 +32,9 @@ const SearchWidget = ({ onChange, onKeyDown, onClick }: SearchWidgetProps) => {
           widthValue={664}
         />
       </Box>
-        <PrimaryButton onClick={onClick}>Check token</PrimaryButton>
+      <PrimaryButton onClick={loading ? null : onClick}>
+        {loading ? <StyledSpinner /> : "Check token"}
+      </PrimaryButton>
     </SearchRow>
   );
 };

--- a/lib/hooks/tokens/useRegisteredTokens.tsx
+++ b/lib/hooks/tokens/useRegisteredTokens.tsx
@@ -9,6 +9,7 @@ interface RegisteredTokens {
   registeredTokens: string[];
   refreshRegisteredTokens: any;
   error?: string;
+  loading: boolean;
 }
 
 const UseRegisteredTokensContext = React.createContext<RegisteredTokens>(null);
@@ -44,7 +45,7 @@ export function UseRegisteredTokens({ children }) {
     return addresses;
   };
 
-  const { data, error, mutate } = useSWR("fetchTokens", fetchTokens);
+  const { data, error, mutate, isValidating: loading } = useSWR("fetchTokens", fetchTokens);
 
   useEffect(() => {
     if (error) setAlertMessage(error);
@@ -56,6 +57,7 @@ export function UseRegisteredTokens({ children }) {
         registeredTokens: data,
         refreshRegisteredTokens: mutate,
         error,
+        loading
       }}
     >
       {children}

--- a/pages/tokens/add.tsx
+++ b/pages/tokens/add.tsx
@@ -16,7 +16,7 @@ import SectionTitle from "../../components/sectionTitle";
 import SearchWidget from "../../components/searchWidget";
 import { PrimaryButton, SecondaryButton } from "../../components/button";
 
-const StyledSpinner = styled(Spinner)`
+export const StyledSpinner = styled(Spinner)`
   color: ${({ theme }) => theme.accent2};
 `;
 
@@ -90,13 +90,13 @@ const TokenAddPage = () => {
   const [loadingToken, setLoadingToken] = useState(false);
   const [registeringToken, setRegisteringToken] = useState(false);
   const { setAlertMessage } = useMessageAlert();
-  const { refreshRegisteredTokens, registeredTokens } = useRegisteredTokens();
+  const { refreshRegisteredTokens, registeredTokens, loading } = useRegisteredTokens();
   const [alreadyRegistered, setAlreadyRegistered] = useState(false);
 
   // Callbacks
 
   const checkToken = () => {
-    if (loadingToken || !formTokenAddress) return;
+    if (loadingToken || !formTokenAddress || loading) return;
     else if (!formTokenAddress.match(/^0x[0-9a-fA-F]{40}$/)) {
       return setAlertMessage("The token address is not valid");
     } else if (registeredTokens.includes(formTokenAddress)) {
@@ -179,8 +179,11 @@ const TokenAddPage = () => {
         />
         <SearchWidget
           onKeyDown={(ev) => (ev.key == "Enter" ? checkToken() : null)}
-          onChange={(ev) => setFormTokenAddress(ev.target.value)}
+          onChange={(ev: React.ChangeEvent<HTMLInputElement>) =>
+            setFormTokenAddress(ev.target.value)
+          }
           onClick={loadingToken ? undefined : checkToken}
+          loading={loading && !registeredTokens?.length}
         />
 
         <br />


### PR DESCRIPTION
# Short description
Right now, if you go to the app and try to search for a token immediately after getting into the register view, you will get an error. In this PR we aim to fix this, by adding a loader so the user can only search when the registered tokens are fetched

# How can it be tested
Go to the review app and try to search for a token immediately after you go to register token page

# Tracker ID
https://linear.app/aragon/issue/VOT-212/fail-check-token