### PR TITLE
Fix: Login before registering a token

### DIFF
--- a/pages/tokens/add.tsx
+++ b/pages/tokens/add.tsx
@@ -15,6 +15,7 @@ import Button from "../../components/button";
 import SectionTitle from "../../components/sectionTitle";
 import SearchWidget from "../../components/searchWidget";
 import { PrimaryButton, SecondaryButton } from "../../components/button";
+import { ActionTypes, useModal } from "../../components/Modal/context";
 
 const StyledSpinner = styled(Spinner)`
   color: ${({ theme }) => theme.accent2};
@@ -84,6 +85,8 @@ const WhiteSection = styled.div`
 const TokenAddPage = () => {
   const wallet = useWallet();
   const signer = useSigner();
+  const { dispatch } = useModal();
+
   const { poolPromise } = usePool();
   const [formTokenAddress, setFormTokenAddress] = useState<string>(null);
   const [tokenInfo, setTokenInfo] = useState<TokenInfo>(null);
@@ -117,15 +120,14 @@ const TokenAddPage = () => {
       });
   };
 
+  const isConnected = wallet.connector || wallet.account;
+
   const onSubmit = useCallback(async () => {
     if (!tokenInfo) return;
-    if (!wallet.connector || !wallet.account) {
-      try {
-        //@TODO: When wallet modal PR is merged, open that modal here
-        await wallet.connect("injected");
-      } catch (e) {
-        return setAlertMessage("Web3 support is not available");
-      }
+    if (!isConnected) {
+      return dispatch({
+        type: ActionTypes.OPEN_WALLET_LIST,
+      });
     }
 
     try {
@@ -224,7 +226,9 @@ const TokenAddPage = () => {
                   Token is already registered
                 </SecondaryButton>
               ) : (
-                <PrimaryButton onClick={onSubmit}>Register token</PrimaryButton>
+                <PrimaryButton onClick={onSubmit}>
+                  {!isConnected ? "Connect wallet" : "Register token"}
+                </PrimaryButton>
               )}
             </ButtonRow>
           </>


### PR DESCRIPTION
# Short description
Currently, if you try to register a token without haven't logged in, it will throw an error

# How can it be tested
Go to review app and try to register a token without haven't logged in, the login modal will appear

# Tracker ID
https://linear.app/aragon/issue/VOT-213/register-button-for-not-connected
