### PR TITLE
chore: dvote-js bumped to 1.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5969,16 +5969,16 @@
       }
     },
     "dvote-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dvote-js/-/dvote-js-1.3.1.tgz",
-      "integrity": "sha512-nIaO06MoytxJRAXzetqQAkM3pc+w9CLHReQ+DFuEVjSUKl1t7t+JB3ow7lvHIvY5xlVEH/BldwdXoPvLMM9OGw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dvote-js/-/dvote-js-1.3.2.tgz",
+      "integrity": "sha512-Gxj3NFtEteLHllqBzbCKanuqOnRX1iIYma/jerPOk+HTUBLABkomwY8knwMdiK2SNz65W2/bC84q4+nisOyJZw==",
       "requires": {
         "@vocdoni/storage-proofs-eth": "^0.2.3",
         "axios": "^0.21.1",
         "blindsecp256k1": "0.0.6",
         "buffer": "^6.0.3",
         "circomlib": "^0.1.2",
-        "dvote-solidity": "^1.2.0",
+        "dvote-solidity": "^1.3.1",
         "ethers": "^5.0.23",
         "google-protobuf": "^3.14.0",
         "iso-language-codes": "^1.0.6",
@@ -5993,9 +5993,9 @@
       }
     },
     "dvote-solidity": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/dvote-solidity/-/dvote-solidity-1.2.0.tgz",
-      "integrity": "sha512-s48QVj+xFf9+aLVJuCbvlMFyaSEWInDxU0q7j7DG8uGmxhizsFlshT1aH1xZE5nzregpjuRVtCBcYSfzZCdZPQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dvote-solidity/-/dvote-solidity-1.3.1.tgz",
+      "integrity": "sha512-pC2Ik1GcYCGscBvemnFlL4t+nJAggQDeHolFnQx3EJHLb8chSmHzakrRhaaNOXsNXCO8n6frkvhH83+oZkaZVw==",
       "requires": {
         "@openzeppelin/contracts": "^3.1.0",
         "eth-ens-namehash": "^2.0.8",
@@ -8811,9 +8811,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.15.8",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.8.tgz",
-      "integrity": "sha512-2jtfdqTaSxk0cuBJBtTTWsot4WtR9RVr2rXg7x7OoqiuOKopPrwXpM1G4dXIkLcUNRh3RKzz76C8IOkksZSeOw=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.16.0.tgz",
+      "integrity": "sha512-gBY66yYL1wbQMU2r1POkXSXkm035Ni0wFv3vx0K9IEUsJLP9G5rAcFVn0xUXfZneRu6MmDjaw93pt/DE56VOyw=="
     },
     "got": {
       "version": "9.6.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bluebird": "^3.7.2",
     "dayjs": "^1.10.4",
     "dexie": "^3.0.3",
-    "dvote-js": "1.3.1",
+    "dvote-js": "1.3.2",
     "eslint": "^7.14.0",
     "ethers": "^5.0.25",
     "ethers-multicall": "^0.2.0",


### PR DESCRIPTION
# Short description
Updates the dvote-js version from 1.3.1 to 1.3.2

# How can it be tested
Check `tokenCount()`,  should work without changes

# Tracker ID
Not tracked
