### PR TITLE
fix: support maker abi and encoding

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -10,6 +10,14 @@ export const ERC20_ABI = [
   "function totalSupply() public view returns (uint256)",
 ];
 
+export const ERC20_ABI_MAKER = [
+  "function name() public view returns (bytes32)",
+  "function symbol() public view returns (bytes32)",
+  "function decimals() public view returns (uint8)",
+  "function balanceOf(address _owner) public view returns (uint256 balance)",
+  "function totalSupply() public view returns (uint256)",
+];
+
 // from aragon/use-wallet
 export const TRUST_WALLET_BASE_URL =
   "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum";

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -5,7 +5,7 @@ export const featuredTokens = {
     "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9", // AAVE
     "0x2aec18c5500f21359ce1bea5dc1777344df4c0dc", // FTT
     "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0", // MATIC
-    // "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2", // MKR
+    "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2", // MKR
     "0xc00e94cb662c3520282e6f5717214004a7f26888", // COMP
     "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f", // SNX
     "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2", // SUSHI


### PR DESCRIPTION
# Short description
MKR token ABI is different (name and symbol are stored in bytes32, instead of string) and we are not able to fetch info from it in the current app

# How can it be tested
- Go to this branch locally (`git fetch` + `git checkout`)
- Set up the `.env`:
```
# Bridge UI
BRIDGE_UI_TAG=main
VOCDONI_ENVIRONMENT=prod
BOOTNODES_URL=https://bootnodes.vocdoni.net/gateways.json
ETH_NETWORK_ID=mainnet
ETH_CHAIN_ID=1
NODE_ENV=production
# Traefik
DOMAIN=bridge.example.com
LE_EMAIL=info@example.com
```
- Run the app and see that makes is being showed in top tokens

# Tracker ID
https://linear.app/aragon/issue/VOT-215/cant-register-mkr