### PR TITLE
Waiting until the new process is effectively available on the vochain

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -189,3 +189,29 @@ export function getRegisteredTokenList(
       );
     });
 }
+
+/** Waits for a while and returns true when the given process is already available for the given entity. 
+ * Returns false after 30 failed attempts.
+ */
+export async function waitUntilProcessCreated(processId: string, tokenAddress: string, pool: GatewayPool): Promise<boolean> {
+  let retries = 30;
+  let processList = await VotingApi.getProcessList({ entityId: tokenAddress }, pool);
+
+  const trimProcId = processId.replace(/^0x/, "");
+  let start = processList.length;
+
+  while (retries >= 0) {
+    while (!processList.some(v => v == trimProcId)) {
+      processList = await VotingApi.getProcessList({ entityId: tokenAddress, from: start }, pool);
+      if (!processList.length) break;
+
+      start += processList.length;
+    }
+    if (processList.length && processList.some(v => v == trimProcId)) {
+      return true;
+    }
+    await new Promise(r => setTimeout(r, 4000)) // Wait 4s;
+    retries--;
+  }
+  return false;
+}

--- a/pages/processes/new.tsx
+++ b/pages/processes/new.tsx
@@ -33,7 +33,7 @@ import Tooltip from "../../components/tooltip";
 import { findMaxValue } from "../../lib/utils";
 import { useToken } from "../../lib/hooks/tokens";
 import { ETH_BLOCK_HEIGHT_PADDING } from "../../lib/constants";
-import { getProof } from "../../lib/api";
+import { getProof, waitUntilProcessCreated } from "../../lib/api";
 import { NO_TOKEN_BALANCE } from "../../lib/errors";
 
 const NewProcessContainer = styled.div`
@@ -370,10 +370,15 @@ const NewProcessPage = () => {
       };
 
       const processId = await VotingApi.newProcess(processParamsPre, signer, pool);
+
+      // Wait until effectively created
+      const ready = await waitUntilProcessCreated(processId, tokenInfo.address, pool);
+      if (!ready) throw new Error("The proposal is not available after a while");
+
       Router.push("/processes#/" + processId);
       setSubmitting(false);
 
-      setAlertMessage("The governance process has been successfully created", "success");
+      setAlertMessage("The proposal has been successfully created", "success");
     } catch (err) {
       setSubmitting(false);
 
@@ -382,7 +387,7 @@ const NewProcessPage = () => {
       }
 
       console.error(err);
-      setAlertMessage("The governance process could not be created");
+      setAlertMessage("The proposal could not be created");
     }
   };
 


### PR DESCRIPTION
# Short description
New processes need to be created on Ethereum as well as on the Vochain. 
However, process creation is not waiting for the second step. This leads to bad UX because of not seing the upcoming process until later.

# How can it be tested
**_Instructions on what the user should do in the review app in order to see the new functionality/fix_**

# Tracker ID
**_Link of Linear issue_**
