### PR TITLE
Feature/vot 274 catch errors on proposal creation

### DIFF
--- a/pages/processes/new.tsx
+++ b/pages/processes/new.tsx
@@ -410,20 +410,7 @@ const NewProcessPage = () => {
           ? await submitBindingVote(pool, startBlock, blockCount)
           : await submitSignalingVote(pool, startBlock, blockCount);
 
-      // Wait until effectively created
-      const ready = await waitUntilProcessCreated(processId, pool);
-      if (!ready) {
-        // If process was created but isn't ready after a while, send the user back to
-        // token information and notify them about the process not being ready.
-        Router.push("/tokens/info#/" + tokenInfo.address);
-        return setAlertMessage(
-          "The process was created, but is not yet available. Please try again later.",
-          "warning"
-        );
-      }
-
-      setSubmitting(false);
-      setAlertMessage("The proposal has been successfully created", "success");
+      // At this point, the proposal is created.
 
       const analytics_properties = {
         entity_id: tokenAddress,
@@ -440,7 +427,21 @@ const NewProcessPage = () => {
       tokenInfo.processes.push(processId);
       storeTokens([tokenInfo]);
 
-      Router.push("/processes#/" + processId);
+      // Wait until effectively ready on entity
+      const ready = await waitUntilProcessCreated(processId, pool);
+      setSubmitting(false);
+      if (!ready) {
+        // If process was created but isn't ready after a while, send the user back to
+        // token information and notify them about the process not being ready.
+        Router.push("/tokens/info#/" + tokenInfo.address);
+        setAlertMessage(
+          "The process was created, but is not yet available. Please try again later.",
+          "warning"
+        );
+      } else {
+        setAlertMessage("The proposal has been successfully created", "success");
+        Router.push("/processes#/" + processId);
+      }
     } catch (error) {
       setSubmitting(false);
 


### PR DESCRIPTION
# Short description
This PR sends a user back to the token-info page if a process was created but is not ready on an entity after a certain time interval. In that case, the user would be stuck on the new-proposal page, as the process is not ready to be shown on its own page. To avoid this, the user is sent back to the token's info page where they can wait for the token to show up.

# Tracker ID
VOT-274
