### PR TITLE
Fix for explorer URL 404 error

### DIFF
--- a/pages/processes/index.tsx
+++ b/pages/processes/index.tsx
@@ -55,7 +55,7 @@ const ProcessPage = () => {
   useScrollTop();
   useOnNetworkChange();
   const processId = useProcessIdFromUrl();
-  const explorerURI = BUILD.explorer + '/elections/show/#/'+processId
+  const explorerURI = BUILD.explorer + '/processes/show/#/'+processId
 
   const { setAlertMessage } = useMessageAlert();
   const { address: holderAddress, methods, status: signerStatus } = useSigner();


### PR DESCRIPTION
# Short description
**_This URL wasn't working: https://azeno.explorer.vote/elections/show/#/21b2ea5345d2e0c941dd44ff4c43fc4683088b846ddb3234d1690b0400000020

So changed 'elections' for 'processes' as per this working URL: https://azeno.explorer.vote/processes/show/#/21b2ea5345d2e0c941dd44ff4c43fc4683088b846ddb3234d1690b0400000020_**

# How can it be tested
**_Test it in staging env_**

# Tracker ID
**_N/A_**
